### PR TITLE
Added validation to ISBN length

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -13,31 +13,34 @@ class BooksController < ApplicationController
   end
 
   def create
-    response = Faraday.get("https://www.googleapis.com/books/v1/volumes?q=isbn:#{params[:isbn]}")
-    json = JSON.parse(response.body, symbolize_names: true)
+    if params[:isbn].length == 10
+      response = Faraday.get("https://www.googleapis.com/books/v1/volumes?q=isbn:#{params[:isbn]}")
+      json = JSON.parse(response.body, symbolize_names: true)
 
+      book = Book.create(isbn: params[:isbn],
+                      title: json[:items][0][:volumeInfo][:title],
+                      cover_image: json[:items][0][:volumeInfo][:imageLinks][:thumbnail],
+                      description: json[:items][0][:volumeInfo][:description],
+                      publication_date: json[:items][0][:volumeInfo][:publishedDate],
+                      category: json[:items][0][:volumeInfo][:categories][0],
+                      maturity: json[:items][0][:volumeInfo][:maturityRating],
+                      info_link: json[:items][0][:volumeInfo][:infoLink])
 
+      json_authors = json[:items][0][:volumeInfo][:authors]
+      json_authors.each do |author|
+        author_object = Author.find_or_create_by(name: author)
+        AuthorBook.create(author_id: author_object.id, book_id: book.id)
+      end
 
-    book = Book.create(isbn: params[:isbn],
-                    title: json[:items][0][:volumeInfo][:title],
-                    cover_image: json[:items][0][:volumeInfo][:imageLinks][:thumbnail],
-                    description: json[:items][0][:volumeInfo][:description],
-                    publication_date: json[:items][0][:volumeInfo][:publishedDate],
-                    category: json[:items][0][:volumeInfo][:categories][0],
-                    maturity: json[:items][0][:volumeInfo][:maturityRating],
-                    info_link: json[:items][0][:volumeInfo][:infoLink])
-
-    json_authors = json[:items][0][:volumeInfo][:authors]
-    json_authors.each do |author|
-      author_object = Author.find_or_create_by(name: author)
-      AuthorBook.create(author_id: author_object.id, book_id: book.id)
-    end
-
-    if book.save
-      redirect_to "/books/#{book.id}"
-      flash[:success] ="You succesfully added a book to the database"
+      if book.save
+        redirect_to "/books/#{book.id}"
+        flash[:success] ="You succesfully added a book to the database"
+      else
+        flash[:notice] = "Book not created, please try again"
+        render :new
+      end
     else
-      flash[:notice] = "Book not created, please try again"
+      flash[:notice] = "We could not complete your request. Please make sure you entered an ISBN-10 with no dashes."
       render :new
     end
   end

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,7 +1,9 @@
 <h1>Add A Book to the Black Voices Matter Database</h1>
 
+<p>Please only enter ISBN-10 numbers and remove all dashes before entering</p>
+
 <%= form_tag "/books" do %>
-  <%= label_tag "ISBN Number" %>
+  <%= label_tag "ISBN-10 Number" %>
   <%= text_field_tag :isbn %><br>
   <%= submit_tag 'Submit' %>
 <% end %>

--- a/spec/features/new_book_creation_spec.rb
+++ b/spec/features/new_book_creation_spec.rb
@@ -13,24 +13,39 @@ RSpec.describe "As a visitor,", type: :feature do
       book = Book.last
       expect(page).to have_content("You succesfully added a book to the database")
       expect(current_path).to eq("/books/#{book.id}")
-
     end
 
     it "doesn't allow you to enter the same book twice" do
-    visit '/books/new'
+      visit '/books/new'
 
-    fill_in :isbn, with: "0439023440"
+      fill_in :isbn, with: "0439023440"
 
-    click_on "Submit"
+      click_on "Submit"
 
-    visit '/books/new'
+      visit '/books/new'
 
-    fill_in :isbn, with: "0439023440"
+      fill_in :isbn, with: "0439023440"
 
-    click_on "Submit"
+      click_on "Submit"
 
-    expect(page).to have_content("Book not created, please try again")
+      expect(page).to have_content("Book not created, please try again")
+    end
 
-    end 
+    it "doesn't allow you to enter an ISBN that is longer than 10 digits" do
+
+      visit '/books/new'
+
+      fill_in :isbn, with: "043902344045"
+
+      click_on "Submit"
+
+      expect(page).to have_content("We could not complete your request. Please make sure you entered an ISBN-10 with no dashes.")
+
+      fill_in :isbn, with: "04-3902-3440"
+
+      click_on "Submit"
+
+      expect(page).to have_content("We could not complete your request. Please make sure you entered an ISBN-10 with no dashes.")
+    end
   end
 end


### PR DESCRIPTION
## Description
Adds check to make sure that ISBN that is entered is exactly 10 characters long, effectively removing the potential for users to enter ISBN 12 or an ISBN with the dashes included.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Closes #6 

## RSpec Results
12 examples, 0 failures
```

```
