### PR TITLE
feature: Create GET authors/id endpoint to return specifc author + test

### DIFF
--- a/app/controllers/api/v1/authors_controller.rb
+++ b/app/controllers/api/v1/authors_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::AuthorsController < ApplicationController
+  def index
+    authors = Author.all
+    render json: AuthorSerializer.new(authors)
+  end
+
+  def show
+    author = Author.find(params[:id])
+    render json: AuthorSerializer.new(author)
+   rescue ActiveRecord::RecordNotFound
+   	render json: { code: "404", message: "Author Not Found" }
+  end
+end

--- a/app/serializers/author_serializer.rb
+++ b/app/serializers/author_serializer.rb
@@ -1,0 +1,7 @@
+class AuthorSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, 
+  					 :name, 
+  					 :created_at, 
+  					 :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      get "/authors/:id", to: "authors#show"
       get "/books", to: "books#index"
+      get "/books/:id", to: "books#show"
     end
   end
 end

--- a/spec/requests/api/v1/authors_requests_spec.rb
+++ b/spec/requests/api/v1/authors_requests_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Authors API' do
+  it "retrieves individual author information" do
+    test_author = Author.create(name: "AuthorTest")
+
+    get "/api/v1/authors/#{test_author.id}"
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+
+    expect(result.size).to eq(1)
+    expect(result[:data]).to include({
+    	:id => a_kind_of(String),
+    	:type => "author",
+    	:attributes => a_hash_including(
+    		:id => a_kind_of(Integer),
+    		:name => "AuthorTest",
+    		:created_at => a_kind_of(String),
+    		:updated_at => a_kind_of(String)
+    		)
+    	})
+  end
+end


### PR DESCRIPTION
## Description

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Issue #23 
- Add GET `/authors/:id` endpoint to return specified Author information from database
  - `Api::V1::AuthorsController` supports return of _all_ Authors, however route is not implemented with this PR
- Add _basic_ test (Spec) to validate response data and structure

**Note:** included rudimentary `404` handling; recommend standardized error handling for API
## RSpec Results
```
As a visitor,
  when I visit /books
    I see a list of all of the books that have been entered in the database

As a visitor,
  when I visit /books/:id
    I see an option to delete that book and can click the link to delete the book

As a visitor,
  when I visit /books/new
    then I can complete a form to add a new book to the database
    doesn't allow you to enter the same book twice
    doesn't allow you to enter an ISBN that is longer than 10 digits

Author
  validations
    is expected to validate that :name cannot be empty/falsy
  relationships
    is expected to have many author_books
    is expected to have many books through author_books

Book
  validations
    is expected to validate that :title cannot be empty/falsy
    is expected to validate that :isbn cannot be empty/falsy
  relationships
    is expected to have many author_books
    is expected to have many authors through author_books

Authors API
  retrieves individual author information

Books API
  retrieves book information

Finished in 3.08 seconds (files took 2.72 seconds to load)
14 examples, 0 failures
```
