### PR TITLE
feature: Create GET books/id endpoint to return specific book + test

### DIFF
--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -4,4 +4,11 @@ class Api::V1::BooksController < ApplicationController
     books = Book.all
     render json: BookSerializer.new(books)
   end
+
+  def show
+    book = Book.find(params[:id])
+    render json: BookSerializer.new(book)
+   rescue ActiveRecord::RecordNotFound
+   	render json: { code: "404", message: "Book Not Found" }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
       
       get "/books", to: "books#index"
       get "/books/:id", to: "books#show"
-
     end
   end
 end

--- a/spec/requests/api/v1/book_requests_spec.rb
+++ b/spec/requests/api/v1/book_requests_spec.rb
@@ -15,4 +15,18 @@ describe 'Books API' do
     results = JSON.parse(response.body, symbolize_names: true)
     expect(response).to be_successful
   end
+
+  it "retrieves individual book information" do
+    test_book = Book.create(isbn: "0241346843", title: "Little Leaders: Bold Women in Black History")
+    test_author = Author.create(name: "Vashti Harrison")
+
+    AuthorBook.create(book_id: test_book.id, author_id: test_author.id)
+
+    get "/api/v1/books/#{test_book.id}"
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(result.size).to eq(1)
+    expect(result[:data][:type]).to eq("book")
+  end
 end


### PR DESCRIPTION
## Description

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Issue #21

Add (_controller code_) for GET `books/:id` endpoint to return specified Book information from database
Add _basic_ test (Spec) to validate response data

*Note:* included rudimentary 404 handling; recommend standardized error handling for API
## RSpec Results
```
As a visitor,
  when I visit /books
    I see a list of all of the books that have been entered in the database

As a visitor,
  when I visit /books/:id
    I see an option to delete that book and can click the link to delete the book

As a visitor,
  when I visit /books/new
    then I can complete a form to add a new book to the database
    doesn't allow you to enter the same book twice
    doesn't allow you to enter an ISBN that is longer than 10 digits

Author
  validations
    is expected to validate that :name cannot be empty/falsy
  relationships
    is expected to have many author_books
    is expected to have many books through author_books

Book
  validations
    is expected to validate that :title cannot be empty/falsy
    is expected to validate that :isbn cannot be empty/falsy
  relationships
    is expected to have many author_books
    is expected to have many authors through author_books

Authors API
  retrieves author information
  retrieves individual author information

Books API
  retrieves book information
  retrieves individual book information

Finished in 3.21 seconds (files took 1.69 seconds to load)
16 examples, 0 failures
```
