### PR TITLE
fix Book.create when categories nil + test

### DIFF
--- a/app/services/book_service.rb
+++ b/app/services/book_service.rb
@@ -14,7 +14,7 @@ class BookService
 
     Book.create(isbn: isbn,
                 title: volume_info[:title],
-                cover_image: volume_info[:imageLinks][:thumbnail],
+                cover_image: volume_info[:imageLinks].nil? ? nil : volume_info[:imageLinks][:thumbnail],
                 description: volume_info[:description],
                 publication_date: volume_info[:publishedDate],
                 category: volume_info[:categories].nil? ? nil : volume_info[:categories][0],

--- a/app/services/book_service.rb
+++ b/app/services/book_service.rb
@@ -10,14 +10,16 @@ class BookService
 
   def create_book(isbn)
     json = JSON.parse(conn(isbn).body, symbolize_names: true)
+    volume_info = json[:items][0][:volumeInfo]
+
     Book.create(isbn: isbn,
-                title: json[:items][0][:volumeInfo][:title],
-                cover_image: json[:items][0][:volumeInfo][:imageLinks][:thumbnail],
-                description: json[:items][0][:volumeInfo][:description],
-                publication_date: json[:items][0][:volumeInfo][:publishedDate],
-                category: json[:items][0][:volumeInfo][:categories][0],
-                maturity: json[:items][0][:volumeInfo][:maturityRating],
-                info_link: json[:items][0][:volumeInfo][:infoLink])
+                title: volume_info[:title],
+                cover_image: volume_info[:imageLinks][:thumbnail],
+                description: volume_info[:description],
+                publication_date: volume_info[:publishedDate],
+                category: volume_info[:categories].nil? ? nil : volume_info[:categories][0],
+                maturity: volume_info[:maturityRating],
+                info_link: volume_info[:infoLink])
   end
 
   def create_author(isbn, book)

--- a/spec/features/new_book_creation_spec.rb
+++ b/spec/features/new_book_creation_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "As a visitor,", type: :feature do
       expect(page).to have_content("We could not complete your request. Please make sure you entered an ISBN-10 with no dashes.")
     end
 
-    it "allows me to add new book, with no category assignements, to the database" do
+    it "allows me to add new book, with no category assignments, to the database" do
       visit '/books/new'
 
       fill_in :isbn, with: "0241346843"

--- a/spec/features/new_book_creation_spec.rb
+++ b/spec/features/new_book_creation_spec.rb
@@ -47,5 +47,17 @@ RSpec.describe "As a visitor,", type: :feature do
 
       expect(page).to have_content("We could not complete your request. Please make sure you entered an ISBN-10 with no dashes.")
     end
+
+    it "allows me to add new book, with no category assignements, to the database" do
+      visit '/books/new'
+
+      fill_in :isbn, with: "0241346843"
+
+      click_on "Submit"
+
+      book = Book.last
+      expect(page).to have_content("You succesfully added a book to the database")
+      expect(current_path).to eq("/books/#{book.id}")
+    end
   end
 end


### PR DESCRIPTION
## Description
Fixed case where the book to be added/created does have Category information.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
#30
- Fix case when adding a book which does not have Category information
- Includes minor refactor of `BookService`
- Includes new test for fix

## RSpec Results
```
As a visitor,
  when I visit /books
    I see a list of all of the books that have been entered in the database

As a visitor,
  when I visit /books/:id
    I see an option to delete that book and can click the link to delete the book

As a visitor,
  when I visit /books/new
    then I can complete a form to add a new book to the database
    doesn't allow you to enter the same book twice
    doesn't allow you to enter an ISBN that is longer than 10 digits
    allows me to add new book, with no category assignments, to the database

Author
  validations
    is expected to validate that :name cannot be empty/falsy
  relationships
    is expected to have many author_books
    is expected to have many books through author_books

Book
  validations
    is expected to validate that :title cannot be empty/falsy
    is expected to validate that :isbn cannot be empty/falsy
  relationships
    is expected to have many author_books
    is expected to have many authors through author_books

Authors API
  retrieves author information
  retrieves individual author information

Books API
  retrieves book information

Finished in 3.67 seconds (files took 1.71 seconds to load)
16 examples, 0 failures
```
